### PR TITLE
Replace prints with logging

### DIFF
--- a/application/use_cases/run_realtime_trading.py
+++ b/application/use_cases/run_realtime_trading.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import time
+import logging
 
 from domain.entities.currency_pair import CurrencyPair
 from domain.services.deal_service import DealService
@@ -11,6 +12,8 @@ from infrastructure.repositories.tickers_repository import InMemoryTickerReposit
 from domain.services.ticker_service import TickerService
 from application.utils.performance_logger import PerformanceLogger
 from domain.services.signal_cooldown_manager import SignalCooldownManager
+
+logger = logging.getLogger(__name__)
 
 
 async def run_realtime_trading(
@@ -30,7 +33,7 @@ async def run_realtime_trading(
 
     counter = 0
 
-    print("🚀 Запуск расширенного торгового цикла с OrderExecutionService + BuyOrderMonitor")
+    logger.info("🚀 Запуск расширенного торгового цикла с OrderExecutionService + BuyOrderMonitor")
 
     try:
         while True:
@@ -46,7 +49,10 @@ async def run_realtime_trading(
 
                 if len(repository.tickers) < 50:
                     if counter % 100 == 0:
-                        print(f"🟡 Накоплено {len(repository.tickers)} тиков, нужно 50")
+                        logger.info(
+                            "🟡 Накоплено %s тиков, нужно 50",
+                            len(repository.tickers),
+                        )
                     continue
 
                 ticker_signal = await ticker_service.get_signal()
@@ -74,21 +80,31 @@ async def run_realtime_trading(
 
                             if not can_buy:
                                 if counter % 20 == 0:
-                                    print(f"🚫 BUY заблокирован: {reason} | Цена: {current_price}")
+                                    logger.info(
+                                        "🚫 BUY заблокирован: %s | Цена: %s",
+                                        reason,
+                                        current_price,
+                                    )
                                 continue
 
-                            print("\n" + "="*80)
-                            print("🟢🔥 MACD СИГНАЛ ПОКУПКИ ОБНАРУЖЕН! ВЫПОЛНЯЕМ ЧЕРЕЗ OrderExecutionService...")
-                            print("="*80)
+                            logger.info("\n" + "=" * 80)
+                            logger.info(
+                                "🟢🔥 MACD СИГНАЛ ПОКУПКИ ОБНАРУЖЕН! ВЫПОЛНЯЕМ ЧЕРЕЗ OrderExecutionService..."
+                            )
+                            logger.info("=" * 80)
 
                             macd = last_ticker.signals.get('macd', 0.0)
                             signal = last_ticker.signals.get('signal', 0.0)
                             hist = last_ticker.signals.get('histogram', 0.0)
 
-                            print(f"   📈 MACD > Signal: {macd:.6f} > {signal:.6f}")
-                            print(f"   📊 Histogram: {hist:.6f}")
-                            print(f"   💰 Текущая цена: {current_price} USDT")
-                            print(f"   🎯 Активных сделок: {active_deals_count}/{currency_pair.deal_count}")
+                            logger.info("   📈 MACD > Signal: %.6f > %.6f", macd, signal)
+                            logger.info("   📊 Histogram: %.6f", hist)
+                            logger.info("   💰 Текущая цена: %s USDT", current_price)
+                            logger.info(
+                                "   🎯 Активных сделок: %s/%s",
+                                active_deals_count,
+                                currency_pair.deal_count,
+                            )
 
                             try:
                                 strategy_result = ticker_service.calculate_strategy(
@@ -102,10 +118,13 @@ async def run_realtime_trading(
                                 )
 
                                 if isinstance(strategy_result, dict) and "comment" in strategy_result:
-                                    print(f"❌ Ошибка в калькуляторе: {strategy_result['comment']}")
+                                    logger.error(
+                                        "❌ Ошибка в калькуляторе: %s",
+                                        strategy_result["comment"],
+                                    )
                                     continue
 
-                                print("🚀 Выполнение стратегии через OrderExecutionService...")
+                                logger.info("🚀 Выполнение стратегии через OrderExecutionService...")
                                 execution_result = await order_execution_service.execute_trading_strategy(
                                     currency_pair=currency_pair,
                                     strategy_result=strategy_result,
@@ -122,59 +141,65 @@ async def run_realtime_trading(
                                 )
 
                                 if execution_result.success:
-                                    print("🎉 СТРАТЕГИЯ ВЫПОЛНЕНА УСПЕШНО!")
+                                    logger.info("🎉 СТРАТЕГИЯ ВЫПОЛНЕНА УСПЕШНО!")
                                 else:
-                                    print(f"❌ СТРАТЕГИЯ НЕ ВЫПОЛНЕНА: {execution_result.error_message}")
+                                    logger.error(
+                                        "❌ СТРАТЕГИЯ НЕ ВЫПОЛНЕНА: %s",
+                                        execution_result.error_message,
+                                    )
 
                             except Exception as calc_error:
-                                print(f"❌ Ошибка в стратегии: {calc_error}")
+                                logger.exception(
+                                    "❌ Ошибка в стратегии: %s",
+                                    calc_error,
+                                )
 
-                            print("="*80)
-                            print("🔄 Продолжаем мониторинг...\n")
+                            logger.info("=" * 80)
+                            logger.info("🔄 Продолжаем мониторинг...\n")
 
                 if counter % 100 == 0:
                     execution_stats = order_execution_service.get_execution_statistics()
-                    print(f"\n📊 СТАТИСТИКА OrderExecutionService (тик {counter}):")
-                    print(f"   🚀 Всего выполнений: {execution_stats['total_executions']}")
-                    print(f"   ✅ Успешных: {execution_stats['successful_executions']}")
-                    print(f"   ❌ Неудачных: {execution_stats['failed_executions']}")
+                    logger.info("\n📊 СТАТИСТИКА OrderExecutionService (тик %s):", counter)
+                    logger.info("   🚀 Всего выполнений: %s", execution_stats["total_executions"])
+                    logger.info("   ✅ Успешных: %s", execution_stats["successful_executions"])
+                    logger.info("   ❌ Неудачных: %s", execution_stats["failed_executions"])
 
                     order_stats = order_execution_service.order_service.get_statistics()
-                    print(f"   📦 Всего ордеров: {order_stats['total_orders']}")
-                    print(f"   🔄 Открытых ордеров: {order_stats['open_orders']}")
+                    logger.info("   📦 Всего ордеров: %s", order_stats["total_orders"])
+                    logger.info("   🔄 Открытых ордеров: %s", order_stats["open_orders"])
 
                     active_deals = len(deal_service.get_open_deals())
-                    print(f"   💼 Активных сделок: {active_deals}")
+                    logger.info("   💼 Активных сделок: %s", active_deals)
 
                     monitor_stats = buy_order_monitor.get_statistics()
-                    print(f"\n🕒 СТАТИСТИКА BuyOrderMonitor:")
-                    print(f"   🔍 Проверок выполнено: {monitor_stats['checks_performed']}")
-                    print(f"   🚨 Тухляков найдено: {monitor_stats['stale_orders_found']}")
-                    print(f"   ❌ Ордеров отменено: {monitor_stats['orders_cancelled']}")
-                    print(f"   🔄 Ордеров пересоздано: {monitor_stats['orders_recreated']}")
+                    logger.info("\n🕒 СТАТИСТИКА BuyOrderMonitor:")
+                    logger.info("   🔍 Проверок выполнено: %s", monitor_stats["checks_performed"])
+                    logger.info("   🚨 Тухляков найдено: %s", monitor_stats["stale_orders_found"])
+                    logger.info("   ❌ Ордеров отменено: %s", monitor_stats["orders_cancelled"])
+                    logger.info("   🔄 Ордеров пересоздано: %s", monitor_stats["orders_recreated"])
 
             except Exception as e:
-                print(f"❌ Ошибка в торговом цикле: {e}")
+                logger.exception("❌ Ошибка в торговом цикле: %s", e)
                 await asyncio.sleep(1)
 
     except KeyboardInterrupt:
-        print("🛑 Получен сигнал остановки...")
+        logger.info("🛑 Получен сигнал остановки...")
     finally:
-        print("🚨 Выполнение экстренной остановки...")
+        logger.info("🚨 Выполнение экстренной остановки...")
         emergency_result = await order_execution_service.emergency_stop_all_trading()
-        print(f"🚨 Экстренная остановка завершена: {emergency_result}")
+        logger.info("🚨 Экстренная остановка завершена: %s", emergency_result)
 
         final_monitor_stats = buy_order_monitor.get_statistics()
-        print("🕒 ФИНАЛЬНАЯ СТАТИСТИКА BuyOrderMonitor:")
-        print(f"   🔍 Всего проверок: {final_monitor_stats['checks_performed']}")
-        print(f"   🚨 Всего тухляков: {final_monitor_stats['stale_orders_found']}")
-        print(f"   ❌ Всего отменено: {final_monitor_stats['orders_cancelled']}")
-        print(f"   🔄 Всего пересоздано: {final_monitor_stats['orders_recreated']}")
+        logger.info("🕒 ФИНАЛЬНАЯ СТАТИСТИКА BuyOrderMonitor:")
+        logger.info("   🔍 Всего проверок: %s", final_monitor_stats["checks_performed"])
+        logger.info("   🚨 Всего тухляков: %s", final_monitor_stats["stale_orders_found"])
+        logger.info("   ❌ Всего отменено: %s", final_monitor_stats["orders_cancelled"])
+        logger.info("   🔄 Всего пересоздано: %s", final_monitor_stats["orders_recreated"])
 
         final_stats = order_execution_service.get_execution_statistics()
-        print("📊 ФИНАЛЬНАЯ СТАТИСТИКА OrderExecutionService:")
-        print(f"   🚀 Всего выполнений: {final_stats['total_executions']}")
-        print(f"   ✅ Успешных: {final_stats['successful_executions']}")
-        print(f"   📈 Процент успеха: {final_stats['success_rate']:.1f}%")
-        print(f"   💰 Общий объем: {final_stats['total_volume']:.4f} USDT")
-        print(f"   💸 Общие комиссии: {final_stats['total_fees']:.4f} USDT")
+        logger.info("📊 ФИНАЛЬНАЯ СТАТИСТИКА OrderExecutionService:")
+        logger.info("   🚀 Всего выполнений: %s", final_stats["total_executions"])
+        logger.info("   ✅ Успешных: %s", final_stats["successful_executions"])
+        logger.info("   📈 Процент успеха: %.1f%%", final_stats["success_rate"])
+        logger.info("   💰 Общий объем: %.4f USDT", final_stats["total_volume"])
+        logger.info("   💸 Общие комиссии: %.4f USDT", final_stats["total_fees"])

--- a/sandbox.py
+++ b/sandbox.py
@@ -3,6 +3,9 @@ from domain.entities.currency_pair import CurrencyPair
 from domain.factories.deal_factory import DealFactory
 from infrastructure.repositories.deals_repository import InMemoryDealsRepository
 from infrastructure.repositories.orders_repository import InMemoryOrdersRepository
+import logging
+
+logger = logging.getLogger(__name__)
 
 def main():
     cp = CurrencyPair(base_currency="BTC", quote_currency="USDT")
@@ -16,7 +19,7 @@ def main():
 
     # 1) Создаём сделку
     deal = deal_factory.create_new_deal(cp)
-    print("New Deal:", deal)
+    logger.info("New Deal: %s", deal)
 
     # 2) Сохраняем сделку
     deals_repo.save(deal)
@@ -28,12 +31,12 @@ def main():
 
     # 3) Проверим get_all_by_deal:
     buy_and_sell = orders_repo.get_all_by_deal(deal.deal_id)
-    print("Orders for this deal:", buy_and_sell)
+    logger.info("Orders for this deal: %s", buy_and_sell)
 
     # 4) Закроем сделку
     deal.close()
     deals_repo.save(deal)  # сохраним статус
-    print("Closed deal:", deal)
+    logger.info("Closed deal: %s", deal)
 
 if __name__ == "__main__":
     main()

--- a/sandbox_websocket.py
+++ b/sandbox_websocket.py
@@ -2,7 +2,11 @@ import asyncio
 import ccxt.pro as pro
 import sys
 import time
+import logging
 from datetime import datetime
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
 
 # 🛠 Фикс для Windows: устанавливаем совместимый event loop
 if sys.platform == "win32":
@@ -29,10 +33,10 @@ async def websocket_price_monitor(exchange, symbol):
                       f" close: {ticker['close']:.2f} |"
                       f" Δt: {time_diff:.3f}s")
 
-            print(output)
+            logger.info(output)
 
         except Exception as e:
-            print(f"WebSocket Error: {e}")
+            logger.exception("WebSocket Error: %s", e)
 
 
 async def main():

--- a/sandbox_websocket_watch_order_book.py
+++ b/sandbox_websocket_watch_order_book.py
@@ -14,6 +14,7 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(levelname)s - %(message)s",
 )
+logger = logging.getLogger(__name__)
 
 # Константы
 HISTORY_SIZE = 500
@@ -29,8 +30,7 @@ fake_orders = set()
 
 def log_event(message):
     """Логирует события в файл и выводит в консоль."""
-    logging.info(message)
-    print(message)
+    logger.info(message)
 
 def track_levels(levels_dict, levels, timestamp):
     """Отслеживает уровни поддержки/сопротивления и выявляет фейковые заявки."""
@@ -123,32 +123,45 @@ async def websocket_order_book_monitor(exchange, symbol):
             timestamp = time.time()
             analysis = analyze_order_book(order_book, timestamp)
 
-            print("\033c", end="")
+            logger.info("\033c")
 
-            print(f"\n📈 {symbol} | Best Bid: {analysis['best_bid']:.4f} | Best Ask: {analysis['best_ask']:.4f}")
-            print(f"💰 Объем покупок: {analysis['total_bids']:.2f} | 📉 Объем продаж: {analysis['total_asks']:.2f}")
-            print(f"⚖️ Имбаланс: {analysis['imbalance']:.2f} | 📊 Настроение: {analysis['market_sentiment']}")
-            print(f"🔮 {analysis['break_probability']}\n")
+            logger.info(
+                "\n📈 %s | Best Bid: %.4f | Best Ask: %.4f",
+                symbol,
+                analysis["best_bid"],
+                analysis["best_ask"],
+            )
+            logger.info(
+                "💰 Объем покупок: %.2f | 📉 Объем продаж: %.2f",
+                analysis["total_bids"],
+                analysis["total_asks"],
+            )
+            logger.info(
+                "⚖️ Имбаланс: %.2f | 📊 Настроение: %s",
+                analysis["imbalance"],
+                analysis["market_sentiment"],
+            )
+            logger.info("🔮 %s\n", analysis["break_probability"])
 
-            print("📉 Уровни поддержки:")
+            logger.info("📉 Уровни поддержки:")
             for level in analysis["support_levels"]:
-                print(level)
+                logger.info(level)
 
-            print("\n📈 Уровни сопротивления:")
+            logger.info("\n📈 Уровни сопротивления:")
             for level in analysis["resistance_levels"]:
-                print(level)
+                logger.info(level)
 
-            print("\n🔥 **Крупные заявки покупателей (🔵):**")
+            logger.info("\n🔥 **Крупные заявки покупателей (🔵):**")
             for price, volume in analysis["big_bids"]:
-                print(f"   {price:.3f} USDT | Объем: {volume:.2f} 🔵")
+                logger.info("   %.3f USDT | Объем: %.2f 🔵", price, volume)
 
-            print("\n🔥 **Крупные заявки продавцов (🔴):**")
+            logger.info("\n🔥 **Крупные заявки продавцов (🔴):**")
             for price, volume in analysis["big_asks"]:
-                print(f"   {price:.3f} USDT | Объем: {volume:.2f} 🔴")
+                logger.info("   %.3f USDT | Объем: %.2f 🔴", price, volume)
 
-            print("\n⚠️ **Топ 10 фейковых заявок:**")
+            logger.info("\n⚠️ **Топ 10 фейковых заявок:**")
             for price, volume in analysis["fake_orders"]:
-                print(f"   {price:.3f} USDT | Объем: {volume:.2f} ⚠️")
+                logger.info("   %.3f USDT | Объем: %.2f ⚠️", price, volume)
 
             await asyncio.sleep(1)
 

--- a/sandbox_websocket_watch_trades.py
+++ b/sandbox_websocket_watch_trades.py
@@ -2,7 +2,11 @@ import asyncio
 import ccxt.pro as pro
 import sys
 import time
+import logging
 from datetime import datetime
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
 
 if sys.platform == "win32":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
@@ -23,10 +27,10 @@ async def websocket_trade_monitor(exchange, symbol):
 
                     output = f"{symbol}{trade['id']} | Price: {trade['price']:.2f} | {trade['side']} | Amount: {trade['amount']:.6f}| Cost: {trade['cost']:.6f} | Δt: {time_diff:.3f}s"
 
-                    print(f"\r{output}", end="\n", flush=False)
+                    logger.info(output)
 
             except Exception as e:
-                print(e)
+                logger.exception(e)
 
 
 async def main():


### PR DESCRIPTION
## Summary
- switch scripting modules to standard logging
- remove all `print` calls and use `logging` across sandbox scripts and realtime trading use case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68727bdb955883299015ca8061831c39