### PR TITLE
Add Binance sandbox integration test

### DIFF
--- a/src/domain/entities/order.py
+++ b/src/domain/entities/order.py
@@ -507,5 +507,25 @@ def validate_ccxt_order_structure(data: Dict[str, Any]) -> tuple[bool, List[str]
     
     if 'timestamp' in data and not isinstance(data['timestamp'], int):
         errors.append("timestamp must be an integer")
-    
+
     return len(errors) == 0, errors
+
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class ExchangeInfo:
+    """Info about a trading pair from the exchange."""
+
+    symbol: str
+    min_qty: float
+    max_qty: float
+    step_size: float
+    min_price: float
+    max_price: float
+    tick_size: float
+    min_notional: float
+    fees: Dict[str, float]
+    precision: Dict[str, float]

--- a/tests/integration/test_real_exchange_compatibility.py
+++ b/tests/integration/test_real_exchange_compatibility.py
@@ -1,0 +1,59 @@
+import os
+import pytest
+import ccxt
+
+from src.infrastructure.connectors.exchange_connector import CcxtExchangeConnector
+
+pytestmark = pytest.mark.asyncio
+
+SANDBOX_API_KEY = os.getenv("BINANCE_SANDBOX_API_KEY")
+SANDBOX_SECRET = os.getenv("BINANCE_SANDBOX_SECRET")
+
+
+@pytest.fixture
+async def connector():
+    if not SANDBOX_API_KEY or not SANDBOX_SECRET:
+        pytest.skip("Binance sandbox credentials not configured")
+    os.environ["BINANCE_SANDBOX_API_KEY"] = SANDBOX_API_KEY
+    os.environ["BINANCE_SANDBOX_SECRET"] = SANDBOX_SECRET
+    conn = CcxtExchangeConnector("binance", use_sandbox=True)
+    yield conn
+    await conn.close()
+
+
+async def watch_with_reconnect(conn, symbol, attempts=2):
+    for _ in range(attempts):
+        try:
+            return await conn.watch_ticker(symbol)
+        except ccxt.BaseError:
+            await conn.close()
+            conn = CcxtExchangeConnector("binance", use_sandbox=True)
+    raise RuntimeError("watch_ticker failed after retries")
+
+
+async def test_order_lifecycle_with_reconnect(connector):
+    symbol = "BTC/USDT"
+
+    ticker = await watch_with_reconnect(connector, symbol)
+    assert "last" in ticker
+    last_price = ticker["last"]
+
+    price = round(last_price * 0.5, 2)
+    amount = 0.001
+
+    order = await connector.create_order(symbol, "buy", "limit", amount, price)
+    order_id = order["id"]
+    assert order_id
+
+    fetched = await connector.fetch_order(order_id, symbol)
+    assert fetched["status"] in {"open", "canceled", "closed"}
+
+    await connector.cancel_order(order_id, symbol)
+    canceled = await connector.fetch_order(order_id, symbol)
+    assert canceled["status"] in {"canceled", "closed"}
+    open_orders = await connector.fetch_open_orders(symbol)
+    assert order_id not in [o["id"] for o in open_orders]
+
+    await connector.client.close()
+    ticker = await watch_with_reconnect(connector, symbol)
+    assert "last" in ticker


### PR DESCRIPTION
## Summary
- add Binance sandbox integration test
- skip production demo if API keys aren't provided
- expose ExchangeInfo dataclass for backward compat

## Testing
- `pip install -r /tmp/req.txt`
- `pytest -q` *(fails: Network is unreachable and various errors)*

------
https://chatgpt.com/codex/tasks/task_e_68860189eeb483298058fd6cd5b64a06