### PR TITLE
Improve CCXT order sync

### DIFF
--- a/src/infrastructure/connectors/ccxt_exchange_connector.py
+++ b/src/infrastructure/connectors/ccxt_exchange_connector.py
@@ -218,9 +218,19 @@ class CCXTExchangeConnector:
         try:
             trades = await self.stream_client.watch_trades(symbol)
             return trades
-            
+
         except Exception as e:
             logger.error(f"Failed to watch trades for {symbol}: {e}")
+            raise
+
+    async def watch_orders(self, symbol: Optional[str] = None) -> Dict[str, Any]:
+        """WebSocket стрим ордеров (CCXT order structure)"""
+        if not self.stream_client:
+            raise RuntimeError("WebSocket client not initialized")
+        try:
+            return await self.stream_client.watch_orders(symbol)
+        except Exception as e:
+            logger.error(f"Failed to watch orders for {symbol or 'all symbols'}: {e}")
             raise
 
     async def watch_ohlcv(self, symbol: str, timeframe: str = '1m') -> List[List]:


### PR DESCRIPTION
## Summary
- compute fees from `trades` when processing CCXT responses
- stream order updates with new `watch_orders`
- update execution service to record fees

## Testing
- `pip install -r requirements.txt` *(fails: ta-lib wheel build error)*
- `pytest -q` *(fails: 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6886018725d083299d0210f087d1f349