### PR TITLE
Improve Order repository with batch save and JSONB handling

### DIFF
--- a/src/domain/repositories/i_orders_repository.py
+++ b/src/domain/repositories/i_orders_repository.py
@@ -21,6 +21,11 @@ class IOrdersRepository(ABC):
         pass
 
     @abstractmethod
+    async def save_orders_batch(self, orders: List[Order]) -> int:
+        """Сохранить несколько ордеров за один запрос"""
+        pass
+
+    @abstractmethod
     async def get_order(self, order_id: str) -> Optional[Order]:
         """Получить ордер по CCXT ID (exchange order ID)"""
         pass


### PR DESCRIPTION
## Summary
- add `save_orders_batch` to orders repository interface
- implement batch save, asyncpg errors and health-check in PostgreSQL repository
- test JSONB round-trip and batch save

## Testing
- `pip install -r requirements.txt` *(fails: ta-lib build error)*
- `pytest tests/infrastructure/repositories/test_postgresql_orders_repository_ccxt.py::TestPostgreSQLOrdersRepositoryCCXT::test_json_fields_round_trip -q` *(fails: no collectors found)*

------
https://chatgpt.com/codex/tasks/task_e_6886018503548329909c9d46dc6c6fe5