### PR TITLE
feat: add ticker repository persistence

### DIFF
--- a/src/infrastructure/repositories/tickers_repository.py
+++ b/src/infrastructure/repositories/tickers_repository.py
@@ -1,19 +1,30 @@
+"""Repository for storing tickers in memory with optional persistence."""
+
 import json
 import os
-import pandas as pd
-from typing import List, Dict
+from typing import List
+
 from domain.entities.ticker import Ticker
 
 
 class InMemoryTickerRepository:
-    def __init__(self, max_size: int = 1000, dump_file: str = "tickers_dump.json"):
-        self.tickers = []
+    """In-memory repository for tickers with caching and persistence."""
+
+    def __init__(
+        self,
+        max_size: int = 1000,
+        dump_file: str = "tickers_dump.json",
+    ):
+        self.tickers: List[Ticker] = []
         self.max_size = max_size
         self.dump_file = dump_file
 
         # 🆕 Кеши для оптимизации
-        self._last_n_cache = {}  # Кеш для get_last_n
+        self._last_n_cache: dict = {}  # Кеш для get_last_n
         self._cache_valid_size = 0  # Размер когда кеш был создан
+
+        # Загружаем тикеры из файла, если он существует
+        self.load_from_file()
 
     def save(self, ticker: Ticker):
         """Оптимизированное сохранение"""
@@ -37,12 +48,42 @@ class InMemoryTickerRepository:
         cache_key = f"last_{n}"
         current_size = len(self.tickers)
 
-        if cache_key in self._last_n_cache and current_size == self._cache_valid_size:
+        if (
+            cache_key in self._last_n_cache
+            and current_size == self._cache_valid_size
+        ):
             return self._last_n_cache[cache_key]
 
         # Создаем результат и кешируем
-        result = self.tickers[-n:] if len(self.tickers) >= n else self.tickers.copy()
+        if len(self.tickers) >= n:
+            result = self.tickers[-n:]
+        else:
+            result = self.tickers.copy()
         self._last_n_cache[cache_key] = result
         self._cache_valid_size = current_size
 
         return result
+
+    def dump_to_file(self) -> None:
+        """Сохраняет тикеры в файл."""
+        with open(self.dump_file, "w", encoding="utf-8") as f:
+            json.dump(
+                [t.to_dict() for t in self.tickers],
+                f,
+                ensure_ascii=False,
+                indent=2,
+            )
+
+    def load_from_file(self) -> None:
+        """Загружает тикеры из файла, если он существует."""
+        if not os.path.exists(self.dump_file):
+            return
+        try:
+            with open(self.dump_file, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except json.JSONDecodeError:
+            data = []
+        self.tickers = [Ticker.from_dict(item) for item in data]
+        # Инвалидация кеша после загрузки
+        self._last_n_cache.clear()
+        self._cache_valid_size = len(self.tickers)


### PR DESCRIPTION
## Summary
- implement JSON-based dump/load for `InMemoryTickerRepository`
- drop unused imports and tidy module docstring

## Testing
- `flake8 src/infrastructure/repositories/tickers_repository.py`
- `PYTHONPATH=src pylint src/infrastructure/repositories/tickers_repository.py`


------
https://chatgpt.com/codex/tasks/task_e_68b15f3196388329a1bbb2af6f396434